### PR TITLE
CSTORE `CHAINSTORE_PEERS`

### DIFF
--- a/naeural_core/business/base/base_plugin_biz.py
+++ b/naeural_core/business/base/base_plugin_biz.py
@@ -64,6 +64,8 @@ _CONFIG = {
   'FORCED_PAUSE': False,
   'DISABLED': False,
   
+  'CHAINSTORE_PEERS' : [], # list of peers to be used for chainstore and will enable distribution even to non-whitelisted peers
+  
 
   # set this to 1 for real time processing (data will be lost and only latest data be avail)
   # when PROCESS_DELAY is used this should be either bigger than 1 if we want to have previous data

--- a/naeural_core/business/base/base_plugin_biz_api.py
+++ b/naeural_core/business/base/base_plugin_biz_api.py
@@ -228,11 +228,15 @@ class _BasePluginAPIMixin:
     try:
       self.__maybe_wait_for_chain_state_init()
       func = memory.get('__chain_storage_set')
+      specific_peers = self.cfg_chainstore_peers
       if func is not None:
         if debug:
           self.P("Setting data: {} -> {}".format(key, value), color="green")
         self.start_timer("chainstore_set")
-        result = func(key, value, readonly=readonly, token=token, debug=debug)
+        result = func(
+          key, value, 
+          readonly=readonly, token=token, peers=specific_peers, debug=debug
+        )
         elapsed = self.end_timer("chainstore_set")        
         if debug:
           self.P(" ====> `chainstore_set` elapsed time: {:.6f}".format(elapsed), color="green")

--- a/naeural_core/business/default/admin/chain_store_base.py
+++ b/naeural_core/business/default/admin/chain_store_base.py
@@ -54,6 +54,8 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
   CS_STORE = "SSTORE"
   CS_CONFIRM = "SCONFIRM"
   CS_DATA = "CHAIN_STORE_DATA"
+  CS_PEERS = "PEERS"
+
   CS_CONFIRM_BY = "confirm_by"
   CS_CONFIRM_BY_ADDR = "confirm_by_addr"
   CS_CONFIRMATIONS = "confirms"
@@ -109,6 +111,8 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     if self.cfg_chain_store_debug:
       self.P(" === Chain storage dump:\n{}".format(self.json_dumps(self.__chain_storage, indent=2)))
     return
+   
+  
   
   
   def __maybe_refresh_chain_peers(self):
@@ -121,6 +125,8 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     However the chain storage should be also accessible to all the nodes in the network so that 
     they can ALL the values stored in the chain storage publicly
     
+    TODO: add shmem peers mentioned by certain plugins or use internal plugin
+    
     """
     if (self.time() - self.__last_chain_peers_refresh) > self.cfg_chain_peers_refresh_interval:
       _chain_peers = self.bc.get_whitelist(with_prefix=True)
@@ -132,8 +138,18 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     return
   
   
-  def __send_data_to_chain_peers(self, data):
-    self.send_encrypted_payload(node_addr=self.__chain_peers, **data)
+  def __send_data_to_chain_peers(self, data, peers=None):
+    # check if list or str
+    send_to = self.deepcopy(self.__chain_peers)
+    if isinstance(peers, (str, list)) and len(peers) > 0:
+      if isinstance(peers, str):
+        peers = [peers]
+      # end if not a list
+      peers = [peer for peer in peers if peer not in self.__chain_peers]
+      send_to.extend(peers)
+    # end if peers
+      
+    self.send_encrypted_payload(node_addr=send_to, **data)
     return
   
   
@@ -245,6 +261,7 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     readonly=False,
     token=None,
     local_sync_storage_op=False, 
+    peers=None,
     debug=False, 
   ):
     """ 
@@ -273,6 +290,9 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
             
     local_sync_storage_op : bool
       If True will only set the local kv pair without broadcasting to the network
+      
+    peers : list
+      A list of peers to send the data to. If None, will use only the chain peers list.
 
     debug : bool
       If True will print debug messages
@@ -320,7 +340,7 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
         readonly=readonly, token=token,
       )
       if not local_sync_storage_op:      
-        # now send set-value confirmation to all
+        # now send set-value (including confirmation request) to all
         op = {      
             self.CS_OP        : self.CS_STORE,
             self.CS_KEY       : key,        
@@ -328,6 +348,7 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
             self.CS_OWNER     : owner,
             self.CS_TOKEN     : token,
             self.CS_READONLY  : readonly, # if the key is readonly, it will not be overwritten by other owners
+            self.CS_PEERS     : peers,
         }
         self.__ops.append(op)
         if debug:
@@ -407,14 +428,16 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     if self.cfg_chain_store_debug and len(self.__ops) > 0:
       self.P(f" === Broadcasting {len(self.__ops)} chain store {self.CS_STORE} ops to {self.__chain_peers}")
     while len(self.__ops) > 0:
-      data = {
-        self.CS_DATA : self.__ops.popleft()
+      data = self.__ops.popleft()
+      peers = data.get(self.CS_PEERS, None)
+      payload_data = {
+        self.CS_DATA : data
       }
-      self.__send_data_to_chain_peers(data)
+      self.__send_data_to_chain_peers(payload_data, peers=peers)
     return
 
 
-  def __exec_store(self, data):
+  def __exec_store(self, data, peers=None):
     """ 
     This method is called when a store operation is received from the network. The method will:
       - set the value in the chain storage
@@ -446,7 +469,7 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
           self.CS_CONFIRM_BY_ADDR : self.ee_addr,
         }
       }
-      self.__send_data_to_chain_peers(data)
+      self.__send_data_to_chain_peers(data, peers=peers)
     else:
       if self.cfg_chain_store_debug:
         self.P(f" === REMOTE: Store for {key}={value} of {owner} failed", color='r')
@@ -507,7 +530,7 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
       else:
         self.P(f" === PAYLOAD_CSTORE: {operation=} from {alias=} {owner=}")
     if operation == self.CS_STORE:
-      self.__exec_store(data)      
+      self.__exec_store(data, peers=sender) # make sure you send also to the sender
     elif operation == self.CS_CONFIRM:
       self.__exec_received_confirm(data)
     return

--- a/naeural_core/business/default/admin/chain_store_base.py
+++ b/naeural_core/business/default/admin/chain_store_base.py
@@ -124,9 +124,7 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     
     However the chain storage should be also accessible to all the nodes in the network so that 
     they can ALL the values stored in the chain storage publicly
-    
-    TODO: add shmem peers mentioned by certain plugins or use internal plugin
-    
+        
     """
     if (self.time() - self.__last_chain_peers_refresh) > self.cfg_chain_peers_refresh_interval:
       _chain_peers = self.bc.get_whitelist(with_prefix=True)

--- a/naeural_core/utils/plugins_base/plugin_base_utils.py
+++ b/naeural_core/utils/plugins_base/plugin_base_utils.py
@@ -2244,7 +2244,7 @@ class _UtilsBaseMixin(
         if self.e2_addr not in dest:
           # TODO: maybe still return the encrypted data for logging purposes
           if verbose > 0:
-            self.P(f"Payload data not addressed to us. Destination: {dest}. Ignoring.")
+            self.P(f"Payload not for local, dest: {dest}. Ignoring.")
           # endif verbose
           return {}
         # endif destination check
@@ -2257,7 +2257,7 @@ class _UtilsBaseMixin(
           )
           decrypted_data = self.json_loads(str_decrypted_data)
         except Exception as exc:
-          self.P(f"Error while decrypting payload data from {sender}:\n{exc}")
+          self.P(f"Error decrypting data from {sender}, to: {dest}:\n{exc}", color='r')
           if verbose > 0:
             self.P(f"Received data:\n{self.dict_to_str(result)}")
           # endif verbose


### PR DESCRIPTION
fix: chainstore syncs also with specific peers

Deeploy will autocomplete CHAINSTORE_PEERS in plugin instances for multi-worker setup

fix: whitelist safety
