### PR TITLE
feat: add cstore hsync runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@ This file is "alive." `AGENTS.md` is the authoritative source for repository pur
 
 ## Authority & Update Policy
 - Follow `AGENTS.md` when other repo docs drift, then fix the stale doc.
+- For ChainStore/CStore work, use `docs/CSTORE.md` as the quick-state review
+  after reading `AGENTS.md`. It is a subsystem contract note, not a replacement
+  for the repo rules here.
 - Keep write scopes narrow; if a task spans more than one owner area, assign an `integrator-test-executor`.
 - Prefer one responsible agent first. Split work only when there is a clear ownership boundary, hardware/tool boundary, or real parallel slack.
 - Keep append-only sections append-only. Do not rewrite prior lessons to make a new task look cleaner.

--- a/docs/CSTORE.md
+++ b/docs/CSTORE.md
@@ -1,0 +1,188 @@
+# CStore Quick State
+
+## Purpose
+
+Use this document as the fast contract review for ChainStore/CStore work.
+It is intentionally narrower than `AGENTS.md`: it explains how CStore works
+end to end, what `hsync` does, what it does not do, and which follow-up issues
+are still open.
+
+## End-To-End Topology
+
+The CStore stack spans three repositories:
+
+- `core/naeural_core`
+  Owns the runtime storage replica, peer broadcasts, confirmations, and the
+  `chainstore_*` / `chainstore_h*` plugin helpers.
+- `core/edge_node`
+  Owns the thin FastAPI wrapper that exposes CStore operations over HTTP.
+- `sdks/edge-sdk-ts`
+  Owns the JavaScript app-facing client and service methods used by container
+  apps and other edge consumers.
+
+For the `cstore-hsync` workstream, the intended public surface is:
+
+- runtime helper: `chainstore_hsync(hkey, ...)`
+- edge endpoint: `POST /hsync`
+- SDK methods: `cstore.hsync(...)` and `cstore.hsyncFull(...)`
+
+## Storage Model
+
+ChainStore is a replicated key-value map held in local runtime memory and
+persisted through the runtime cache helpers.
+
+- `set` writes one plain key
+- `get` reads one plain key locally
+- `hset` writes one field under a logical hash namespace
+- `hget` reads one field locally
+- `hgetall` reconstructs one hash namespace from local composed keys only
+- `hsync` explicitly asks peers for one full hash namespace snapshot and merges
+  that snapshot into the local replica
+
+Hash namespaces are stored as composed keys. The namespace prefix is derived
+from `hkey`, and each field name is base64-encoded into the final storage key.
+That means `hgetall` is a local scan over the local replica, not a distributed
+query.
+
+## Write Propagation
+
+Current write propagation is push-based:
+
+1. a local caller uses `chainstore_set(...)` or `chainstore_hset(...)`
+2. the runtime stores the value locally
+3. the runtime broadcasts the write to target peers
+4. peers apply the write locally and send confirmations back
+5. the origin waits for the configured minimum confirmations or times out
+
+This solves live replication for writes seen by currently running peers.
+It does not, by itself, replay older writes to a late joiner or a restarted
+peer that was offline while other peers kept accepting writes.
+
+## Read Behavior
+
+`get`, `hget`, and `hgetall` are local reads.
+
+That boundary matters:
+
+- `hgetall` does not fetch missing fields from peers
+- `hgetall` does not repair stale local state
+- local correctness after peer downtime depends on an explicit repair step
+
+`hsync` is that explicit repair step for one hash namespace.
+
+## `hsync` Contract
+
+`hsync` is a merge-refresh for one logical HSET namespace.
+
+Algorithm:
+
+1. resolve the target peer set
+2. send one `SHSYNC_REQ` request containing `request_id` and `hkey`
+3. accept the first valid `SHSYNC_RESP` from an allowed peer
+4. export or consume only the requested namespace snapshot
+5. merge the snapshot into local storage without rebroadcasting it
+
+Merge rules:
+
+- remote fields missing locally are inserted
+- remote fields that overlap local state overwrite the local field
+- local fields absent from the remote snapshot are preserved
+- delete pruning is out of scope
+
+Result rules:
+
+- success returns `{ hkey, source_peer, merged_fields }`
+- an empty snapshot from a valid peer is still success
+- timeout means no valid peer response was accepted
+
+This is deliberately not an exact mirror operation. It repairs missing or stale
+data for one namespace without trying to make the local replica identical to a
+single peer.
+
+## Boot-Time App Pattern
+
+The platform does not own an automatic startup hook for `hsync`.
+Boot-time refresh is an app-layer decision.
+
+Recommended pattern:
+
+1. the app reads one env variable listing the HSET namespaces it wants to
+   refresh before serving traffic
+2. the app calls SDK `hsync(...)` for each namespace during startup
+3. the app chooses whether timeout is fatal, retryable, or best-effort for its
+   own readiness policy
+
+One possible app-owned env contract is:
+
+```text
+APP_CSTORE_HSYNC_HKEYS=players,characters,inventory
+```
+
+Example startup logic once the matching SDK branch is present:
+
+```ts
+const hkeys = (process.env.APP_CSTORE_HSYNC_HKEYS ?? '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean)
+
+for (const hkey of hkeys) {
+  await ratio1.cstore.hsync({ hkey })
+}
+```
+
+Interpretation:
+
+- peer responds with data: app has live peer state for that namespace
+- peer responds with `{ merged_fields: 0 }`: valid cold state, not an error
+- no valid peer responds before timeout: app never confirmed peer state
+
+## New Node vs Restarted Peer
+
+`hsync` exists for both of these cases:
+
+- a brand-new shard/world node starts with no local character data
+- an existing peer restarts with a stale local replica after being offline
+
+The repair need is the same in both cases: local `hgetall` must be refreshed
+from live peer state before the app trusts its local namespace contents.
+
+## Current Issue Triage
+
+Fixed now:
+
+- snapshot export freezes `self.__chain_storage.items()` into a list before
+  filtering, so the export path no longer iterates a live mutable dict view
+
+Open and documented:
+
+- first valid peer response wins; there is no freshness arbitration across
+  multiple peers yet
+- `hsync` is namespace-scoped and merge-only; it is not a whole-cluster
+  consistency pass
+- local-only fields are intentionally preserved, so exact delete reconciliation
+  remains out of scope
+- startup orchestration remains app-owned; the platform still does not auto-run
+  `hsync` during container boot
+
+Improved in this workstream:
+
+- runtime `chainstore_hsync(...)` accepts a caller-provided `timeout`, so the
+  wait budget is no longer hardcoded inside the runtime path
+
+## Next Steps
+
+Small follow-ups:
+
+- expose the runtime `timeout` control consistently through the edge API and
+  SDK if apps need that knob
+- add a small freshness token or version hint so `hsync` can reject obviously
+  stale peer responses
+- add thin edge and SDK tests that lock the `/hsync` request and response shape
+
+Larger follow-ups:
+
+- cluster-level reconciliation for multiple namespaces
+- delete/tombstone reconciliation when exact mirror behavior is required
+- automatic app bootstrap wrappers if the platform later decides to own startup
+  hydration instead of leaving it to apps

--- a/naeural_core/business/base/base_plugin_biz_api.py
+++ b/naeural_core/business/base/base_plugin_biz_api.py
@@ -367,6 +367,40 @@ class _BasePluginAPIMixin:
     return result
 
 
+  def __chainstore_specific_peers(self, extra_peers=None, include_configured_peers=True):
+    """
+    Build the explicit peer override list for one chain-store call.
+
+    This helper keeps ``chainstore_set`` and ``chainstore_hsync`` aligned so
+    both operations interpret configured peers, per-call peers, de-duplication,
+    and self-exclusion in exactly the same way.
+
+    Parameters
+    ----------
+    extra_peers : str or list, optional
+      Additional peer addresses requested by the caller for this operation.
+    include_configured_peers : bool, optional
+      If True, include ``cfg_chainstore_peers`` before appending
+      ``extra_peers``. Default is True.
+
+    Returns
+    -------
+    list or None
+      Explicit peer addresses to forward to the backend helper. ``None`` means
+      that the caller did not request any explicit peer override and the
+      backend should rely only on its default peer set.
+    """
+    specific_peers = []
+    if include_configured_peers:
+      specific_peers.extend(
+        self.__normalize_chainstore_peers(self.cfg_chainstore_peers or [])
+      )
+    for peer in self.__normalize_chainstore_peers(extra_peers):
+      if peer not in specific_peers:
+        specific_peers.append(peer)
+    return specific_peers or None
+
+
   def chainstore_set(
     self,
     key,
@@ -479,16 +513,9 @@ class _BasePluginAPIMixin:
       # would have {"8080": "http"}, causing confirmation comparisons to fail.
       value = self.json_loads(self.json_dumps(value))
 
-      specific_peers = []
-      if include_configured_peers:
-        specific_peers.extend(
-          self.__normalize_chainstore_peers(self.cfg_chainstore_peers or [])
-        )
-      specific_peers.extend(
-        [
-          peer for peer in self.__normalize_chainstore_peers(extra_peers)
-          if peer not in specific_peers
-        ]
+      specific_peers = self.__chainstore_specific_peers(
+        extra_peers=extra_peers,
+        include_configured_peers=include_configured_peers,
       )
       
       if func is not None:
@@ -702,6 +729,89 @@ class _BasePluginAPIMixin:
       value = self.chainstore_hget(hkey, key, token=token, debug=debug)
       result[key] = value
     return result
+
+
+  def chainstore_hsync(
+    self,
+    hkey,
+    debug=False,
+    extra_peers=None,
+    include_default_peers=True,
+    include_configured_peers=True,
+    timeout=None,
+  ):
+    """
+    Refresh one hash namespace from a live peer snapshot.
+
+    The runtime implementation exports one peer snapshot for ``hkey`` and then
+    merges it into the local replica. The merge is additive: remote fields
+    overwrite stale overlaps, while local-only fields remain untouched.
+
+    Parameters
+    ----------
+    hkey : str
+      Logical hash namespace to refresh.
+    debug : bool, optional
+      If True, enable verbose timing and routing logs. Default is False.
+    extra_peers : str or list, optional
+      Additional peer addresses to target for this request. Default is None.
+    include_default_peers : bool, optional
+      If True, include the backend chain-store default peer set in addition to
+      any explicit peers. If False, target only the explicit peer set built
+      from configured and extra peers. Default is True.
+    include_configured_peers : bool, optional
+      If True, include ``cfg_chainstore_peers`` in the explicit peer set for
+      this call. If False, only ``extra_peers`` are used as explicit targets.
+      Default is True.
+    timeout : float, optional
+      Maximum time in seconds to wait for one valid peer snapshot. If None,
+      use the backend default behavior. Default is None.
+
+    Returns
+    -------
+    dict
+      A result envelope with the refreshed ``hkey``, the accepted peer, and
+      the number of merged fields.
+
+    Raises
+    ------
+    ValueError
+      If ``hkey`` is invalid, the backend helper is unavailable, or the peer
+      refresh fails.
+    """
+    self.start_timer("chainstore_hsync")
+    memory = self.__chainstorage_memory()
+    try:
+      self.__maybe_wait_for_chain_state_init()
+      func = memory.get("__chain_storage_hsync")
+      if func is None:
+        raise ValueError("Chain storage hsync function not found.")
+
+      specific_peers = self.__chainstore_specific_peers(
+        extra_peers=extra_peers,
+        include_configured_peers=include_configured_peers,
+      )
+
+      result = func(
+        hkey,
+        peers=specific_peers,
+        include_default_peers=include_default_peers,
+        timeout=timeout,
+        debug=debug,
+      )
+      elapsed = self.end_timer("chainstore_hsync")
+      if debug:
+        self.P(
+          "====> `chainstore_hsync`: {} -> {} in {:.4f}s".format(
+            hkey, result, elapsed
+          )
+        )
+      return result
+    except Exception as ex:
+      elapsed = self.end_timer("chainstore_hsync")
+      msg = "Error in chainstore_hsync: {} after {:.4f}s".format(ex, elapsed)
+      self.P(msg, color="red")
+      raise ValueError(msg) from ex
     
   
   # # @property

--- a/naeural_core/business/default/admin/chain_store_base.py
+++ b/naeural_core/business/default/admin/chain_store_base.py
@@ -76,6 +76,14 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
   CS_STORAGE_MEM = "__chain_storage" # shared memory key
   CS_GETTER = "__chain_storage_get"
   CS_SETTER = "__chain_storage_set"
+  CS_HSYNC = "__chain_storage_hsync"
+  CS_HSYNC_REQ = "SHSYNC_REQ"
+  CS_HSYNC_RESP = "SHSYNC_RESP"
+  CS_REQUEST_ID = "request_id"
+  CS_HKEY = "hkey"
+  CS_SNAPSHOT = "snapshot"
+  CS_RESPONSE = "response"
+  CS_SENDER = "sender"
   
   
   
@@ -107,9 +115,11 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     memory[self.CS_STORAGE_MEM] = self.__chain_storage
     memory[self.CS_GETTER] = self._get_value
     memory[self.CS_SETTER] = self._set_value
+    memory[self.CS_HSYNC] = self._hsync
     
     self.__last_chain_peers_refresh = 0
     self.__chain_peers = []
+    self.__pending_hsync = {}
     self.__maybe_refresh_chain_peers()
     return
   
@@ -268,6 +278,129 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     self.cacheapi_save_pickle(self.__chain_storage, verbose=True)
     self.__last_chain_storage_save = self.time()
     return
+
+
+  def __hset_index(self, hkey):
+    """
+    Compute the composed-key prefix for one hash namespace.
+
+    Parameters
+    ----------
+    hkey : str
+      Logical hash namespace requested by higher-level ``h*`` APIs.
+
+    Returns
+    -------
+    str
+      Prefix shared by every field stored under ``hkey``.
+    """
+    hkey_hash = self.get_hash(hkey, algorithm="sha256", length=10)
+    return f"hs:{hkey_hash}:"
+
+
+  def __export_hset_snapshot(self, hkey):
+    """
+    Export a stable snapshot for one hash namespace.
+
+    Parameters
+    ----------
+    hkey : str
+      Logical hash namespace to export from the local replica.
+
+    Returns
+    -------
+    dict
+      Deep-copied chain-store records keyed by their composed storage key.
+
+    Notes
+    -----
+    The export freezes ``self.__chain_storage.items()`` into a list before
+    filtering. That keeps snapshot generation stable even if another local
+    write mutates the dictionary while the snapshot is being assembled.
+    """
+    index = self.__hset_index(hkey)
+    snapshot = {}
+    # Freeze the current dictionary view before filtering so live writes do not
+    # mutate the iterator while this response is being serialized.
+    for key, record in list(self.__chain_storage.items()):
+      if not isinstance(key, str) or not key.startswith(index):
+        continue
+      if not isinstance(record, dict):
+        continue
+      snapshot[key] = self.deepcopy(record)
+    return snapshot
+
+
+  def __merge_hset_snapshot(self, hkey, snapshot):
+    """
+    Merge one peer-exported snapshot into the local replica.
+
+    Parameters
+    ----------
+    hkey : str
+      Logical hash namespace being refreshed.
+    snapshot : dict
+      Snapshot payload exported by a peer for ``hkey``.
+
+    Returns
+    -------
+    int
+      Number of local fields that were inserted or overwritten from the peer
+      snapshot.
+
+    Notes
+    -----
+    The merge is additive only. Remote fields that overlap the local replica
+    overwrite stale values, while fields absent from the remote snapshot are
+    preserved locally and are never pruned by this method.
+    """
+    if not isinstance(snapshot, dict):
+      return 0
+
+    index = self.__hset_index(hkey)
+    merged_fields = 0
+    changed = False
+    for key, record in snapshot.items():
+      if not isinstance(key, str) or not key.startswith(index):
+        continue
+      if not isinstance(record, dict):
+        continue
+      if self.CS_OWNER not in record or self.CS_VALUE not in record:
+        continue
+
+      value = self.deepcopy(record.get(self.CS_VALUE))
+      if value is None:
+        continue
+
+      readonly = record.get(self.CS_READONLY, False)
+      token = record.get(self.CS_TOKEN, None)
+      local_record = self.__chain_storage.get(key)
+      if isinstance(local_record, dict):
+        same_owner = local_record.get(self.CS_OWNER) == record.get(self.CS_OWNER)
+        same_value = local_record.get(self.CS_VALUE) == value
+        same_readonly = local_record.get(self.CS_READONLY, False) == readonly
+        same_token = local_record.get(self.CS_TOKEN, None) == token
+        if same_owner and same_value and same_readonly and same_token:
+          continue
+
+      # Apply the peer record only to the local replica. HSync intentionally
+      # does not enqueue a broadcast because this node is catching up to peer
+      # state rather than originating a new write.
+      self.__chain_storage[key] = {
+        self.CS_KEY: key,
+        self.CS_VALUE: value,
+        self.CS_OWNER: record.get(self.CS_OWNER),
+        self.CS_READONLY: readonly,
+        self.CS_TOKEN: token,
+        self.CS_CONFIRMATIONS: -1,
+        self.CS_MIN_CONFIRMATIONS: 0,
+      }
+      merged_fields += 1
+      changed = True
+
+    if changed:
+      self.__save_chain_storage()
+    return merged_fields
   
   ## START setter-getter methods
 
@@ -626,6 +759,117 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
     return need_store
 
 
+  def _hsync(
+    self,
+    hkey,
+    peers=None,
+    include_default_peers=True,
+    timeout=None,
+    debug=False,
+  ):
+    """
+    Request one live snapshot for a hash namespace and merge it locally.
+
+    Parameters
+    ----------
+    hkey : str
+      Logical hash namespace to refresh.
+    peers : str or list, optional
+      Explicit peer addresses to target for this refresh. Default is None.
+    include_default_peers : bool, optional
+      If True, also target the runtime default chain-peer set. If False, only
+      the explicit ``peers`` list is used. Default is True.
+    timeout : float, optional
+      Maximum wait time in seconds for one valid peer snapshot. If None, use
+      the built-in default. Default is None.
+    debug : bool, optional
+      If True, print detailed routing and timing logs. Default is False.
+
+    Returns
+    -------
+    dict
+      Result envelope with ``hkey``, the accepted ``source_peer``, and the
+      number of ``merged_fields`` applied locally.
+
+    Raises
+    ------
+    ValueError
+      If ``hkey`` or ``timeout`` is invalid, if no target peer can be
+      resolved, or if no valid peer snapshot is accepted before timeout.
+
+    Notes
+    -----
+    A valid peer response with an empty snapshot is a successful cold-state
+    sync. Timeout means that no valid peer response was accepted at all.
+    """
+    debug = debug or self.cfg_chain_store_debug
+    if not isinstance(hkey, str) or len(hkey) == 0:
+      raise ValueError("hsync hkey must be a non-empty string.")
+    if timeout is not None and (
+      isinstance(timeout, bool) or
+      not isinstance(timeout, (int, float)) or
+      timeout <= 0
+    ):
+      raise ValueError("timeout must be a positive number or None.")
+    if timeout is None:
+      timeout = 10
+
+    explicit_peers = self.__normalize_peer_list(peers)
+    allowed_peers = self.__get_target_peers(
+      peers=explicit_peers,
+      include_default_peers=include_default_peers,
+    )
+    if len(allowed_peers) == 0:
+      raise ValueError(f"No target peers resolved for hsync '{hkey}'.")
+
+    request_id = self.uuid()
+    self.__pending_hsync[request_id] = {
+      self.CS_HKEY: hkey,
+      self.CS_PEERS: allowed_peers,
+      self.CS_RESPONSE: None,
+    }
+
+    try:
+      if debug:
+        self.P(
+          f" === HSYNC request for {hkey} to peers {allowed_peers}",
+          color="green",
+        )
+
+      self.__send_data_to_chain_peers(
+        {
+          self.CS_DATA: {
+            self.CS_OP: self.CS_HSYNC_REQ,
+            self.CS_REQUEST_ID: request_id,
+            self.CS_HKEY: hkey,
+          }
+        },
+        peers=explicit_peers or None,
+        include_default_peers=include_default_peers,
+      )
+
+      deadline = self.time() + timeout
+      while self.time() <= deadline:
+        pending = self.__pending_hsync.get(request_id, {})
+        response = pending.get(self.CS_RESPONSE, None)
+        if response is not None:
+          sender = response.get(self.CS_SENDER, None)
+          snapshot = response.get(self.CS_SNAPSHOT, {})
+          # Empty snapshots still prove that a valid peer answered, so they are
+          # treated as successful cold-state syncs with zero merged fields.
+          merged_fields = self.__merge_hset_snapshot(hkey, snapshot)
+          return {
+            self.CS_HKEY: hkey,
+            "source_peer": sender,
+            "merged_fields": merged_fields,
+          }
+        self.sleep(0.100)
+
+      raise ValueError(f"hsync for '{hkey}' timed out after {timeout}s.")
+    finally:
+      self.__pending_hsync.pop(request_id, None)
+
+
   def _get_value(self, key, token=None, get_owner=False, debug=False):
     """ This method is called to get a value from the chain storage """
     # TODO: Check if this constraint could break anything.
@@ -772,6 +1016,103 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
         self.P(f" === LOCAL: Key {key} confirmed by {confirm_by}")
     return
 
+
+  def __exec_hsync_request(self, data, peers=None):
+    """
+    Reply to a peer snapshot request for one hash namespace.
+
+    Parameters
+    ----------
+    data : dict
+      Decrypted hsync request payload.
+    peers : str or list, optional
+      Sender address or addresses that should receive the snapshot response.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    The response carries only the requested hash namespace snapshot. This
+    keeps the wire payload small and avoids broad chain-store exports.
+    """
+    request_id = data.get(self.CS_REQUEST_ID, None)
+    hkey = data.get(self.CS_HKEY, None)
+    if not isinstance(request_id, str) or len(request_id) == 0:
+      return
+    if not isinstance(hkey, str) or len(hkey) == 0:
+      return
+
+    snapshot = self.__export_hset_snapshot(hkey)
+    if self.cfg_chain_store_debug:
+      self.P(
+        f" === REMOTE: HSYNC request {request_id} for {hkey} back to {peers}",
+        color="green",
+      )
+    self.__send_data_to_chain_peers(
+      {
+        self.CS_DATA: {
+          self.CS_OP: self.CS_HSYNC_RESP,
+          self.CS_REQUEST_ID: request_id,
+          self.CS_HKEY: hkey,
+          self.CS_SNAPSHOT: snapshot,
+        }
+      },
+      peers=peers,
+      include_default_peers=False,
+    )
+    return
+
+
+  def __exec_hsync_response(self, data, sender=None):
+    """
+    Record the first valid peer snapshot response for one pending request.
+
+    Parameters
+    ----------
+    data : dict
+      Decrypted hsync response payload.
+    sender : str, optional
+      Transport-level sender address for the current payload.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    The first valid response wins. This keeps each ``_hsync`` call
+    deterministic and avoids merging multiple peer views into a single refresh
+    operation. Freshness arbitration remains a documented follow-up concern.
+    """
+    request_id = data.get(self.CS_REQUEST_ID, None)
+    pending = self.__pending_hsync.get(request_id, None)
+    if pending is None or pending.get(self.CS_RESPONSE, None) is not None:
+      return
+    if not isinstance(sender, str) or len(sender) == 0:
+      return
+
+    allowed_peers = pending.get(self.CS_PEERS, [])
+    if sender not in allowed_peers:
+      return
+
+    hkey = data.get(self.CS_HKEY, None)
+    if hkey != pending.get(self.CS_HKEY, None):
+      return
+
+    snapshot = data.get(self.CS_SNAPSHOT, {})
+    if not isinstance(snapshot, dict):
+      return
+
+    # Accept only one response from the precomputed peer set so an unrelated
+    # or late peer cannot replace the snapshot chosen for this sync request.
+    pending[self.CS_RESPONSE] = {
+      self.CS_SENDER: sender,
+      self.CS_SNAPSHOT: self.deepcopy(snapshot),
+    }
+    return
+
   @NetworkProcessorPlugin.payload_handler()
   def default_handler(self, payload):
     sender = payload.get(self.const.PAYLOAD_DATA.EE_SENDER, None)
@@ -811,6 +1152,10 @@ class ChainStoreBasePlugin(NetworkProcessorPlugin):
       self.__exec_store(data, peers=sender) # make sure you send also to the sender
     elif operation == self.CS_CONFIRM:
       self.__exec_received_confirm(data)
+    elif operation == self.CS_HSYNC_REQ:
+      self.__exec_hsync_request(data, peers=sender)
+    elif operation == self.CS_HSYNC_RESP:
+      self.__exec_hsync_response(data, sender=sender)
     return
   
 

--- a/naeural_core/business/test_framework/test_chain_store_hsync.py
+++ b/naeural_core/business/test_framework/test_chain_store_hsync.py
@@ -1,0 +1,457 @@
+import base64
+import copy
+import hashlib
+import json
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from naeural_core import __file__ as _NAEURAL_CORE_INIT_FILE
+
+
+def _load_class_from_source(source_path, class_name, extra_globals=None, strip_text=()):
+  source = Path(source_path).read_text(encoding="utf-8")
+  for needle in strip_text:
+    source = source.replace(needle, "")
+  namespace = {"__name__": f"loaded_{class_name}"}
+  if extra_globals:
+    namespace.update(extra_globals)
+  exec(compile(source, str(source_path), "exec"), namespace)  # noqa: S102
+  return namespace[class_name]
+
+
+_BASE_DIR = Path(_NAEURAL_CORE_INIT_FILE).resolve().parent
+_BasePluginAPIMixin = _load_class_from_source(
+  _BASE_DIR / "business" / "base" / "base_plugin_biz_api.py",
+  "_BasePluginAPIMixin",
+)
+
+
+class _FakeNetworkProcessorPlugin:
+  CONFIG = {"VALIDATION_RULES": {}}
+
+  @staticmethod
+  def payload_handler(signature="DEFAULT"):
+    def decorator(func):
+      return func
+
+    return decorator
+
+
+ChainStoreBasePlugin = _load_class_from_source(
+  _BASE_DIR / "business" / "default" / "admin" / "chain_store_base.py",
+  "ChainStoreBasePlugin",
+  extra_globals={"NetworkProcessorPlugin": _FakeNetworkProcessorPlugin},
+  strip_text=("from naeural_core.business.base.network_processor import NetworkProcessorPlugin\n",),
+)
+
+
+class _PayloadData:
+  EE_SENDER = "EE_SENDER"
+  EE_ID = "EE_ID"
+  EE_DESTINATION = "EE_DESTINATION"
+  EE_IS_ENCRYPTED = "EE_IS_ENCRYPTED"
+
+
+class _Const:
+  PAYLOAD_DATA = _PayloadData
+
+
+def _hset_index(hkey):
+  return f"hs:{hashlib.sha256(hkey.encode('utf-8')).hexdigest()[:10]}:"
+
+
+def _hset_key(hkey, field):
+  encoded = base64.urlsafe_b64encode(field.encode("utf-8")).decode("utf-8").rstrip("=")
+  return _hset_index(hkey) + encoded
+
+
+def _chain_store_record(key, value, owner, readonly=False, token=None):
+  return {
+    ChainStoreBasePlugin.CS_KEY: key,
+    ChainStoreBasePlugin.CS_VALUE: value,
+    ChainStoreBasePlugin.CS_OWNER: owner,
+    ChainStoreBasePlugin.CS_READONLY: readonly,
+    ChainStoreBasePlugin.CS_TOKEN: token,
+    ChainStoreBasePlugin.CS_CONFIRMATIONS: 0,
+    ChainStoreBasePlugin.CS_MIN_CONFIRMATIONS: 1,
+  }
+
+
+def _hset_record(hkey, field, value, owner, readonly=False, token=None):
+  key = _hset_key(hkey, field)
+  return key, _chain_store_record(
+    key=key,
+    value=value,
+    owner=owner,
+    readonly=readonly,
+    token=token,
+  )
+
+
+def _build_hset_storage(hkey, fields, owner):
+  storage = {}
+  for field, value in fields.items():
+    key, record = _hset_record(hkey, field, value, owner=owner)
+    storage[key] = record
+  return storage
+
+
+class _PeerSelectionHarness(_BasePluginAPIMixin):
+  def __init__(self):
+    super().__init__()
+    self.cfg_chainstore_peers = ["peer-config", "peer-config", "peer-self"]
+    self.ee_addr = "peer-self"
+    self._now = 0.0
+    self.messages = []
+    self.calls = []
+    self.plugins_shmem = {
+      "__chain_storage_set": self._record_set,
+      "__chain_storage_hsync": self._record_hsync,
+    }
+
+  def P(self, msg, color=None, **kwargs):  # pylint: disable=unused-argument
+    self.messages.append(msg)
+
+  def start_timer(self, _name):
+    return None
+
+  def end_timer(self, _name):
+    return 0.0
+
+  def time(self):
+    return self._now
+
+  def sleep(self, seconds):
+    self._now += seconds
+
+  @staticmethod
+  def json_dumps(value):
+    return json.dumps(value)
+
+  @staticmethod
+  def json_loads(value):
+    return json.loads(value)
+
+  @staticmethod
+  def deepcopy(value):
+    return copy.deepcopy(value)
+
+  def _record_set(self, key, value, **kwargs):
+    self.calls.append(("set", key, value, kwargs))
+    return {"kind": "set", "key": key, "value": value, "kwargs": kwargs}
+
+  def _record_hsync(self, hkey, **kwargs):
+    self.calls.append(("hsync", hkey, kwargs))
+    return {"kind": "hsync", "hkey": hkey, "kwargs": kwargs}
+
+
+class _FakeNetwork:
+  def __init__(self):
+    self.nodes = {}
+
+  def register(self, node):
+    self.nodes[node.ee_addr] = node
+    node.network = self
+
+  def dispatch(self, sender, targets, decoded):
+    if isinstance(targets, str):
+      targets = [targets]
+    elif not isinstance(targets, list):
+      targets = []
+
+    for target in targets:
+      peer = self.nodes.get(target)
+      if peer is None:
+        continue
+      payload = {
+        _PayloadData.EE_SENDER: sender,
+        _PayloadData.EE_ID: sender,
+        _PayloadData.EE_DESTINATION: [target],
+        _PayloadData.EE_IS_ENCRYPTED: True,
+        "decoded": decoded,
+      }
+      peer.default_handler(payload)
+
+
+class _ChainStoreRuntimeHarness(ChainStoreBasePlugin):
+  def __init__(self, ee_addr, default_peers=None, storage=None):
+    self.ee_addr = ee_addr
+    self.ee_id = f"{ee_addr}-id"
+    self._stream_id = "stream"
+    self._signature = "CHAIN_STORE"
+    self.cfg_instance_id = "instance"
+    self.const = _Const
+    self.cfg_chain_store_debug = False
+    self.cfg_chain_peers_refresh_interval = 60
+    self.cfg_min_confirmations = 1
+    self.cfg_max_inputs_queue_size = 1024
+    self.input_queue_size = 0
+    self.network = None
+    self.sent_payloads = []
+    self.messages = []
+    self.saved_storage = []
+    self._now = 0.0
+    self._ChainStoreBasePlugin__chain_storage = copy.deepcopy(storage or {})
+    self._ChainStoreBasePlugin__chain_peers = list(default_peers or [])
+    self._ChainStoreBasePlugin__pending_hsync = {}
+    self._ChainStoreBasePlugin__last_chain_peers_refresh = self._now
+
+  def P(self, msg, color=None, **kwargs):  # pylint: disable=unused-argument
+    self.messages.append(msg)
+
+  def time(self):
+    return self._now
+
+  def sleep(self, seconds):
+    self._now += seconds
+
+  @staticmethod
+  def deepcopy(value):
+    return copy.deepcopy(value)
+
+  @staticmethod
+  def json_dumps(value, **kwargs):
+    return json.dumps(value, **kwargs)
+
+  @staticmethod
+  def json_loads(value):
+    return json.loads(value)
+
+  @staticmethod
+  def str_to_base64(value, url_safe=True):  # pylint: disable=unused-argument
+    raw = value.encode("utf-8")
+    encoded = base64.urlsafe_b64encode(raw) if url_safe else base64.b64encode(raw)
+    return encoded.decode("utf-8").rstrip("=")
+
+  @staticmethod
+  def base64_to_str(value, url_safe=True):  # pylint: disable=unused-argument
+    padding = "=" * ((4 - len(value) % 4) % 4)
+    raw = f"{value}{padding}".encode("utf-8")
+    decoded = base64.urlsafe_b64decode(raw) if url_safe else base64.b64decode(raw)
+    return decoded.decode("utf-8")
+
+  @staticmethod
+  def get_hash(value, algorithm="sha256", length=10):  # pylint: disable=unused-argument
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return digest[:length]
+
+  @staticmethod
+  def uuid(length=8):  # pylint: disable=unused-argument
+    return "req-" + "1" * length
+
+  def cacheapi_save_pickle(self, value, verbose=True):  # pylint: disable=unused-argument
+    self.saved_storage.append(copy.deepcopy(value))
+
+  def cacheapi_load_pickle(self, default=None, verbose=True):  # pylint: disable=unused-argument
+    return copy.deepcopy(default)
+
+  def send_encrypted_payload(self, node_addr=None, **data):
+    self.sent_payloads.append({
+      "node_addr": copy.deepcopy(node_addr),
+      "data": copy.deepcopy(data),
+    })
+    if self.network is not None:
+      self.network.dispatch(self.ee_addr, node_addr, data)
+
+  @staticmethod
+  def receive_and_decrypt_payload(data):
+    return copy.deepcopy(data.get("decoded", {}))
+
+  def trace_info(self):
+    return "trace"
+
+  @property
+  def storage(self):
+    return self._ChainStoreBasePlugin__chain_storage
+
+  @property
+  def pending_hsync(self):
+    return self._ChainStoreBasePlugin__pending_hsync
+
+  def make_request_payload(self, request_id="req-1", sender="peer-requester", hkey="players"):
+    return {
+      _PayloadData.EE_SENDER: sender,
+      _PayloadData.EE_ID: sender,
+      _PayloadData.EE_DESTINATION: [self.ee_addr],
+      _PayloadData.EE_IS_ENCRYPTED: True,
+      "decoded": {
+        self.CS_DATA: {
+          self.CS_OP: self.CS_HSYNC_REQ,
+          self.CS_REQUEST_ID: request_id,
+          self.CS_HKEY: hkey,
+        }
+      },
+    }
+
+  def make_response_payload(self, request_id="req-1", sender="peer-1", hkey="players", snapshot=None):
+    return {
+      _PayloadData.EE_SENDER: sender,
+      _PayloadData.EE_ID: sender,
+      _PayloadData.EE_DESTINATION: [self.ee_addr],
+      _PayloadData.EE_IS_ENCRYPTED: True,
+      "decoded": {
+        self.CS_DATA: {
+          self.CS_OP: self.CS_HSYNC_RESP,
+          self.CS_REQUEST_ID: request_id,
+          self.CS_HKEY: hkey,
+          self.CS_SNAPSHOT: copy.deepcopy(snapshot if snapshot is not None else {}),
+        }
+      },
+    }
+
+
+class TestChainStoreHsync(unittest.TestCase):
+  def test_chainstore_set_and_hsync_share_peer_selection(self):
+    harness = _PeerSelectionHarness()
+
+    set_result = harness.chainstore_set(
+      "alpha",
+      {"nested": {1: "one"}},
+      extra_peers=["peer-extra", "peer-config", "peer-extra"],
+      include_default_peers=False,
+    )
+    hsync_result = harness.chainstore_hsync(
+      "players",
+      extra_peers=["peer-extra", "peer-config", "peer-extra"],
+      include_default_peers=False,
+    )
+
+    self.assertEqual(set_result["kwargs"]["peers"], ["peer-config", "peer-extra"])
+    self.assertEqual(hsync_result["kwargs"]["peers"], ["peer-config", "peer-extra"])
+    self.assertEqual(set_result["kwargs"]["include_default_peers"], False)
+    self.assertEqual(hsync_result["kwargs"]["include_default_peers"], False)
+
+  def test_hsync_uses_backend_default_peers_when_no_explicit_targets(self):
+    requester = _ChainStoreRuntimeHarness("peer-requester", default_peers=["peer-1"])
+    responder = _ChainStoreRuntimeHarness(
+      "peer-1",
+      storage=_build_hset_storage("players", {"alpha": "remote-alpha"}, owner="peer-1"),
+    )
+    network = _FakeNetwork()
+    network.register(requester)
+    network.register(responder)
+
+    result = requester._hsync("players")
+
+    self.assertEqual(
+      result,
+      {"hkey": "players", "source_peer": "peer-1", "merged_fields": 1},
+    )
+    self.assertEqual(requester.sent_payloads[0]["node_addr"], ["peer-1"])
+
+  def test_hsync_overwrites_stale_overlaps_and_preserves_local_only_fields(self):
+    requester = _ChainStoreRuntimeHarness(
+      "peer-requester",
+      storage={
+        **_build_hset_storage("players", {"alpha": "local-alpha", "gamma": "local-gamma"}, owner="peer-requester"),
+      },
+    )
+    responder = _ChainStoreRuntimeHarness(
+      "peer-1",
+      storage=_build_hset_storage("players", {"alpha": "remote-alpha", "beta": "remote-beta"}, owner="peer-1"),
+    )
+    network = _FakeNetwork()
+    network.register(requester)
+    network.register(responder)
+
+    result = requester._hsync("players", peers=["peer-1"], include_default_peers=False)
+
+    self.assertEqual(
+      result,
+      {"hkey": "players", "source_peer": "peer-1", "merged_fields": 2},
+    )
+    self.assertEqual(
+      requester.storage[_hset_key("players", "alpha")][ChainStoreBasePlugin.CS_VALUE],
+      "remote-alpha",
+    )
+    self.assertEqual(
+      requester.storage[_hset_key("players", "beta")][ChainStoreBasePlugin.CS_VALUE],
+      "remote-beta",
+    )
+    self.assertEqual(
+      requester.storage[_hset_key("players", "gamma")][ChainStoreBasePlugin.CS_VALUE],
+      "local-gamma",
+    )
+    self.assertEqual(len(requester.sent_payloads), 1)
+    self.assertEqual(len(responder.sent_payloads), 1)
+
+  def test_hsync_treats_empty_snapshot_as_successful_cold_state(self):
+    requester = _ChainStoreRuntimeHarness(
+      "peer-requester",
+      storage=_build_hset_storage("players", {"alpha": "local-alpha"}, owner="peer-requester"),
+    )
+    responder = _ChainStoreRuntimeHarness("peer-1", storage={})
+    network = _FakeNetwork()
+    network.register(requester)
+    network.register(responder)
+
+    result = requester._hsync("players", peers=["peer-1"], include_default_peers=False)
+
+    self.assertEqual(
+      result,
+      {"hkey": "players", "source_peer": "peer-1", "merged_fields": 0},
+    )
+    self.assertEqual(
+      requester.storage[_hset_key("players", "alpha")][ChainStoreBasePlugin.CS_VALUE],
+      "local-alpha",
+    )
+
+  def test_hsync_times_out_only_when_no_valid_peer_responds(self):
+    requester = _ChainStoreRuntimeHarness("peer-requester", default_peers=["peer-missing"])
+
+    with self.assertRaisesRegex(ValueError, "timed out"):
+      requester._hsync("players", timeout=0.01)
+
+  def test_default_handler_rejects_unrequested_sender_response(self):
+    requester = _ChainStoreRuntimeHarness(
+      "peer-requester",
+      storage=_build_hset_storage("players", {"alpha": "local-alpha"}, owner="peer-requester"),
+    )
+    requester.pending_hsync["req-1"] = {
+      requester.CS_HKEY: "players",
+      requester.CS_PEERS: ["peer-1"],
+      requester.CS_RESPONSE: None,
+    }
+
+    requester.default_handler(
+      requester.make_response_payload(
+        request_id="req-1",
+        sender="rogue-peer",
+        snapshot=_build_hset_storage("players", {"beta": "rogue-beta"}, owner="rogue-peer"),
+      )
+    )
+
+    self.assertIsNone(requester.pending_hsync["req-1"][requester.CS_RESPONSE])
+    self.assertNotIn(_hset_key("players", "beta"), requester.storage)
+    self.assertEqual(len(requester.sent_payloads), 0)
+
+  def test_default_handler_replies_to_request_with_snapshot(self):
+    responder = _ChainStoreRuntimeHarness(
+      "peer-1",
+      storage=_build_hset_storage("players", {"alpha": "remote-alpha"}, owner="peer-1"),
+    )
+
+    responder.default_handler(
+      responder.make_request_payload(request_id="req-1", sender="peer-requester", hkey="players")
+    )
+
+    self.assertEqual(len(responder.sent_payloads), 1)
+    response = responder.sent_payloads[0]
+    self.assertEqual(response["node_addr"], ["peer-requester"])
+    self.assertEqual(
+      response["data"][responder.CS_DATA][responder.CS_OP],
+      responder.CS_HSYNC_RESP,
+    )
+    self.assertEqual(
+      response["data"][responder.CS_DATA][responder.CS_HKEY],
+      "players",
+    )
+    self.assertEqual(
+      response["data"][responder.CS_DATA][responder.CS_SNAPSHOT][_hset_key("players", "alpha")][responder.CS_VALUE],
+      "remote-alpha",
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- rebuild the CStore `hsync` runtime path on top of latest upstream peer-targeting helpers
- add merge-only HSET snapshot refresh with explicit empty-snapshot success semantics
- add focused `test_chain_store_hsync.py` coverage for peer selection, merge behavior, timeout, and handler validation
- add `docs/CSTORE.md` and a narrow `AGENTS.md` reference for future ChainStore/CStore work

## Verification
- pass: `python -m compileall naeural_core/business/base/base_plugin_biz_api.py naeural_core/business/default/admin/chain_store_base.py naeural_core/business/test_framework/test_chain_store_hsync.py`
- pass: `python -m unittest naeural_core.business.test_framework.test_chain_store_hsync -v`
- fail (pre-existing, unrelated): `python -m unittest discover naeural_core/business/test_framework -p 'test_*.py'`
  - `test_netmon_compression.*` expects missing `PAYLOAD_DATA` compression helpers/constants
  - `test_orchestrator_node_oracles.*` expects `_FakeBlockchainManager.evm_network`
  - `test_trt_create_from_onnx.*` imports `torch.dtype` from the local environment and fails before this change is exercised

## Notes
- `hsync` is merge-only: missing remote fields are added, stale overlaps are overwritten, and local-only fields are preserved
- stable snapshot export over a frozen `list(self.__chain_storage.items())` is included in this PR
- freshness arbitration across multiple peers remains a documented follow-up, not part of this surgical change