### PR TITLE
fix: reject stale Deeploy lifecycle commands

### DIFF
--- a/naeural_core/business/mixins_base/cmdapi.py
+++ b/naeural_core/business/mixins_base/cmdapi.py
@@ -694,14 +694,16 @@ class _CmdAPIMixin(object):
 
   # STOP STREAM SECTION
   if True:
-    def _cmdapi_stop_stream(self, node_address=None, stream_name=None):
+    def _cmdapi_stop_stream(self, node_address=None, stream_name=None, command_content=None):
       node_address = node_address or self.node_addr
       stream_name = stream_name or self.get_stream_id()
-      self.cmdapi_register_command(node_address=node_address, command_type=COMMANDS.DELETE_CONFIG, command_content=stream_name)
+      if command_content is None:
+        command_content = stream_name
+      self.cmdapi_register_command(node_address=node_address, command_type=COMMANDS.DELETE_CONFIG, command_content=command_content)
       return
     
-    def cmdapi_stop_pipeline(self, node_address, name):
-      self._cmdapi_stop_stream(node_address=node_address, stream_name=name)
+    def cmdapi_stop_pipeline(self, node_address, name, command_content=None):
+      self._cmdapi_stop_stream(node_address=node_address, stream_name=name, command_content=command_content)
       return
     
     def cmdapi_stop_current_pipeline(self):
@@ -768,4 +770,3 @@ class _CmdAPIMixin(object):
       self._cmdapi_finish_stream_acquisition(node_address=node_address, stream_name=stream_name)
       return
   #endif
-

--- a/naeural_core/business/test_framework/fixtures/deeploy_lifecycle_ordering/old_delete_after_new_update.json
+++ b/naeural_core/business/test_framework/fixtures/deeploy_lifecycle_ordering/old_delete_after_new_update.json
@@ -1,0 +1,27 @@
+{
+  "stream_name": "sentinelapi-0_d60b35d",
+  "current_update": {
+    "NAME": "sentinelapi-0_d60b35d",
+    "TYPE": "Void",
+    "INITIATOR_ID": "manager-new",
+    "SESSION_ID": "session-new",
+    "DEEPLOY_SPECS": {
+      "job_id": 66,
+      "project_id": 12,
+      "lifecycle_generation": 2,
+      "lifecycle_operation": "update",
+      "date_updated": 200.0
+    }
+  },
+  "stale_delete": {
+    "NAME": "sentinelapi-0_d60b35d",
+    "OWNER": "0xowner",
+    "DEEPLOY_SPECS": {
+      "job_id": 66,
+      "project_id": 12,
+      "lifecycle_generation": 1,
+      "lifecycle_operation": "delete",
+      "date_updated": 100.0
+    }
+  }
+}

--- a/naeural_core/business/test_framework/test_deeploy_lifecycle_ordering.py
+++ b/naeural_core/business/test_framework/test_deeploy_lifecycle_ordering.py
@@ -1,0 +1,235 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+from naeural_core import constants as ct
+from naeural_core.config.config_manager_commands import ConfigCommandHandlers
+
+
+_CMDAPI_SPEC = importlib.util.spec_from_file_location(
+  "_deeploy_lifecycle_cmdapi",
+  Path(__file__).resolve().parents[1] / "mixins_base" / "cmdapi.py",
+)
+_CMDAPI_MODULE = importlib.util.module_from_spec(_CMDAPI_SPEC)
+_CMDAPI_SPEC.loader.exec_module(_CMDAPI_MODULE)
+_CmdAPIMixin = _CMDAPI_MODULE._CmdAPIMixin
+
+
+class _NetMonHarness:
+
+  def network_node_eeid(self, node_address):
+    return f"box-{node_address}"
+
+
+class _LogHarness:
+
+  def now_str(self, nice_print=True):
+    return "2026-05-29 00:00:00"
+
+
+class _CmdApiHarness(_CmdAPIMixin):
+
+  def __init__(self):
+    self._commands = []
+    self.commands_deque = []
+    self.net_mon = _NetMonHarness()
+    self.log = _LogHarness()
+    self.use_local_comms_only = False
+    self.node_addr = "local-node"
+    self.logs = []
+
+  def P(self, msg, *args, **kwargs):
+    self.logs.append(str(msg))
+
+  def get_stream_id(self):
+    return "current-stream"
+
+
+class _ConfigManagerHarness(ConfigCommandHandlers):
+
+  def __init__(self, streams=None):
+    self.admin_pipeline_name = "admin_pipeline"
+    self.dct_config_streams = copy.deepcopy(streams or {})
+    self.deleted_streams = []
+    self.saved_streams = []
+    self.notifications = []
+    self.logs = []
+
+  def P(self, msg, *args, **kwargs):
+    self.logs.append(str(msg))
+
+  def _create_notification(self, **kwargs):
+    self.notifications.append(kwargs)
+
+  def _delete_stream_config(self, stream_name):
+    self.deleted_streams.append(stream_name)
+
+  def _save_stream_config(self, config_stream):
+    self.saved_streams.append(copy.deepcopy(config_stream))
+
+  def _check_duplicate_last(self, payload, payload_type):
+    return False
+
+  def _apply_delta_to_config(self, original_config, delta_config, ignore_fields=None):
+    ignored = set(ignore_fields or [])
+    result = copy.deepcopy(original_config)
+    for key, value in delta_config.items():
+      if key not in ignored:
+        result[key] = value
+    return result
+
+  def keep_good_stream(self, config_stream):
+    return config_stream
+
+
+def _deeploy_stream(name="deeploy-app", generation=2, date_updated=200.0):
+  return {
+    ct.CONFIG_STREAM.NAME: name,
+    ct.CONFIG_STREAM.TYPE: "Void",
+    ct.CONFIG_STREAM.INITIATOR_ID: "manager-node",
+    ct.CONFIG_STREAM.SESSION_ID: "session-1",
+    ct.CONFIG_STREAM.DEEPLOY_SPECS: {
+      "lifecycle_generation": generation,
+      "date_updated": date_updated,
+      "job_id": 2002,
+    },
+  }
+
+
+def _delete_payload(name="deeploy-app", generation=1, date_updated=100.0):
+  return {
+    ct.CONFIG_STREAM.NAME: name,
+    ct.CONFIG_STREAM.DEEPLOY_SPECS: {
+      "lifecycle_generation": generation,
+      "date_updated": date_updated,
+      "job_id": 2002,
+    },
+  }
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "deeploy_lifecycle_ordering"
+
+
+class DeeployLifecycleOrderingTests(unittest.TestCase):
+
+  def test_stale_deeploy_delete_does_not_remove_newer_stream(self):
+    manager = _ConfigManagerHarness({"deeploy-app": _deeploy_stream()})
+
+    manager.delete_config_stream(
+      stream_name=_delete_payload(generation=1, date_updated=100.0),
+      initiator_id="manager-node",
+      session_id="session-1",
+    )
+
+    self.assertIn("deeploy-app", manager.dct_config_streams)
+    self.assertEqual(manager.deleted_streams, [])
+    self.assertTrue(any("stale" in log.lower() for log in manager.logs))
+
+  def test_fixture_old_delete_after_new_update_keeps_newer_stream(self):
+    with (FIXTURE_DIR / "old_delete_after_new_update.json").open(encoding="utf-8") as stream:
+      fixture = json.load(stream)
+    stream_name = fixture["stream_name"]
+    manager = _ConfigManagerHarness({stream_name: fixture["current_update"]})
+
+    manager.delete_config_stream(
+      stream_name=fixture["stale_delete"],
+      initiator_id="manager-old",
+      session_id="session-old",
+    )
+
+    self.assertIn(stream_name, manager.dct_config_streams)
+    self.assertEqual(manager.deleted_streams, [])
+    self.assertEqual(
+      manager.dct_config_streams[stream_name][ct.CONFIG_STREAM.DEEPLOY_SPECS]["lifecycle_generation"],
+      2,
+    )
+
+  def test_current_generation_deeploy_delete_removes_stream(self):
+    manager = _ConfigManagerHarness({"deeploy-app": _deeploy_stream()})
+
+    manager.delete_config_stream(
+      stream_name=_delete_payload(generation=2, date_updated=200.0),
+      initiator_id="manager-node",
+      session_id="session-1",
+    )
+
+    self.assertNotIn("deeploy-app", manager.dct_config_streams)
+    self.assertEqual(manager.deleted_streams, ["deeploy-app"])
+
+  def test_legacy_string_delete_remains_unconditional(self):
+    manager = _ConfigManagerHarness({"deeploy-app": _deeploy_stream()})
+
+    manager.delete_config_stream(
+      stream_name="deeploy-app",
+      initiator_id="manager-node",
+      session_id="session-1",
+    )
+
+    self.assertNotIn("deeploy-app", manager.dct_config_streams)
+    self.assertEqual(manager.deleted_streams, ["deeploy-app"])
+
+  def test_stale_deeploy_update_does_not_overwrite_newer_stream(self):
+    manager = _ConfigManagerHarness({"deeploy-app": _deeploy_stream()})
+    update_payload = _deeploy_stream(generation=1, date_updated=100.0)
+    update_payload[ct.CONFIG_STREAM.INITIATOR_ID] = "manager-node"
+
+    manager.update_config_stream(
+      delta_config_stream=update_payload,
+      initiator_id="manager-node",
+      session_id="session-1",
+    )
+
+    self.assertEqual(
+      manager.dct_config_streams["deeploy-app"][ct.CONFIG_STREAM.DEEPLOY_SPECS]["lifecycle_generation"],
+      2,
+    )
+    self.assertEqual(manager.saved_streams, [])
+    self.assertTrue(any("stale" in log.lower() for log in manager.logs))
+
+  def test_newer_deeploy_update_after_delete_tombstone_is_accepted_as_new_stream(self):
+    manager = _ConfigManagerHarness({"deeploy-app": _deeploy_stream(generation=2)})
+
+    manager.delete_config_stream(
+      stream_name=_delete_payload(generation=2, date_updated=200.0),
+      initiator_id="manager-node",
+      session_id="session-1",
+    )
+    manager.update_config_stream(
+      delta_config_stream=_deeploy_stream(generation=3, date_updated=300.0),
+      initiator_id="manager-node",
+      session_id="session-2",
+    )
+
+    self.assertIn("deeploy-app", manager.dct_config_streams)
+    self.assertEqual(
+      manager.dct_config_streams["deeploy-app"][ct.CONFIG_STREAM.DEEPLOY_SPECS]["lifecycle_generation"],
+      3,
+    )
+    self.assertNotIn("lifecycle_generation", manager.dct_config_streams["deeploy-app"])
+    self.assertEqual(
+      manager.saved_streams[-1][ct.CONFIG_STREAM.DEEPLOY_SPECS]["lifecycle_generation"],
+      3,
+    )
+
+  def test_cmdapi_stop_pipeline_can_send_structured_delete_payload(self):
+    cmdapi = _CmdApiHarness()
+    payload = _delete_payload(generation=2, date_updated=200.0)
+
+    cmdapi.cmdapi_stop_pipeline(
+      node_address="node-1",
+      name="deeploy-app",
+      command_content=payload,
+    )
+
+    self.assertEqual(len(cmdapi.commands_deque), 1)
+    sent = cmdapi.commands_deque[0][0]
+    self.assertEqual(sent[1], "node-1")
+    self.assertEqual(sent[3], ct.COMMANDS.DELETE_CONFIG)
+    self.assertEqual(sent[4][ct.CONFIG_STREAM.NAME], "deeploy-app")
+    self.assertIn(ct.PAYLOAD_DATA.TIME, sent[4])
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/naeural_core/config/config_manager_commands.py
+++ b/naeural_core/config/config_manager_commands.py
@@ -3,6 +3,108 @@ import os
 from naeural_core import constants as ct
 
 class ConfigCommandHandlers:
+
+  _DEEPLOY_LIFECYCLE_GENERATION = "lifecycle_generation"
+  _DEEPLOY_DATE_UPDATED = "date_updated"
+
+  def _coerce_deeploy_lifecycle_number(self, value):
+    if isinstance(value, bool) or value is None:
+      return None
+    try:
+      return float(value)
+    except (TypeError, ValueError):
+      return None
+
+  def _get_deeploy_lifecycle_marker(self, payload):
+    if not isinstance(payload, dict):
+      return None
+    specs = payload.get(ct.CONFIG_STREAM.DEEPLOY_SPECS)
+    if not isinstance(specs, dict):
+      return None
+
+    generation = self._coerce_deeploy_lifecycle_number(
+      specs.get(self._DEEPLOY_LIFECYCLE_GENERATION)
+    )
+    date_updated = self._coerce_deeploy_lifecycle_number(
+      specs.get(self._DEEPLOY_DATE_UPDATED)
+    )
+    if generation is None and date_updated is None:
+      return None
+    return {
+      self._DEEPLOY_LIFECYCLE_GENERATION: generation,
+      self._DEEPLOY_DATE_UPDATED: date_updated,
+    }
+
+  def _get_deeploy_lifecycle_tombstones(self):
+    if not hasattr(self, "_deeploy_lifecycle_tombstones"):
+      self._deeploy_lifecycle_tombstones = {}
+    return self._deeploy_lifecycle_tombstones
+
+  def _remember_deeploy_lifecycle_tombstone(self, stream_name, payload):
+    marker = self._get_deeploy_lifecycle_marker(payload)
+    if marker is not None:
+      self._get_deeploy_lifecycle_tombstones()[stream_name] = marker
+    return
+
+  def _clear_deeploy_lifecycle_tombstone(self, stream_name):
+    self._get_deeploy_lifecycle_tombstones().pop(stream_name, None)
+    return
+
+  def _is_stale_deeploy_lifecycle_marker(self, incoming_marker, current_marker):
+    if incoming_marker is None or current_marker is None:
+      return False
+
+    incoming_generation = incoming_marker.get(self._DEEPLOY_LIFECYCLE_GENERATION)
+    current_generation = current_marker.get(self._DEEPLOY_LIFECYCLE_GENERATION)
+    if incoming_generation is not None and current_generation is not None:
+      if incoming_generation < current_generation:
+        return True
+      if incoming_generation > current_generation:
+        return False
+
+    incoming_date = incoming_marker.get(self._DEEPLOY_DATE_UPDATED)
+    current_date = current_marker.get(self._DEEPLOY_DATE_UPDATED)
+    if incoming_date is not None and current_date is not None:
+      return incoming_date < current_date
+    return False
+
+  def _should_skip_stale_deeploy_lifecycle_command(
+    self,
+    command_name,
+    stream_name,
+    incoming_payload,
+    current_payload,
+    initiator_id,
+    session_id,
+  ):
+    incoming_marker = self._get_deeploy_lifecycle_marker(incoming_payload)
+    current_marker = self._get_deeploy_lifecycle_marker(current_payload)
+    if self._is_stale_deeploy_lifecycle_marker(incoming_marker, current_marker):
+      msg = (
+        "Skipping stale Deeploy {} for pipeline '{}': incoming lifecycle {} "
+        "is older than current lifecycle {}."
+      ).format(command_name, stream_name, incoming_marker, current_marker)
+      self.P(msg, color='y')
+      self._create_notification(
+        notif=ct.STATUS_TYPE.STATUS_NORMAL,
+        msg=msg,
+        stream_name=stream_name,
+        session_id=session_id,
+        initiator_id=initiator_id,
+        displayed=True,
+      )
+      return True
+    return False
+
+  def _normalize_delete_config_payload(self, stream_name):
+    if not isinstance(stream_name, dict):
+      return stream_name, None
+    delete_payload = stream_name
+    normalized_name = (
+      delete_payload.get(ct.CONFIG_STREAM.NAME)
+      or delete_payload.get(ct.CONFIG_STREAM.K_NAME)
+    )
+    return normalized_name, delete_payload
   
   def update_config_stream(self, delta_config_stream, initiator_id, session_id, verbose=1):
     stream_name = delta_config_stream[ct.CONFIG_STREAM.NAME]
@@ -41,6 +143,19 @@ class ConfigCommandHandlers:
       return     
     #endif admin pipeline modification is not allowed 
       
+    config_stream = self.dct_config_streams.get(stream_name, {})
+    lifecycle_current_payload = config_stream
+    if len(config_stream) == 0:
+      lifecycle_current_payload = self._get_deeploy_lifecycle_tombstones().get(stream_name, {})
+    if self._should_skip_stale_deeploy_lifecycle_command(
+      command_name=ct.PAYLOAD_CT.COMMANDS.UPDATE_CONFIG,
+      stream_name=stream_name,
+      incoming_payload=delta_config_stream,
+      current_payload=lifecycle_current_payload,
+      initiator_id=initiator_id,
+      session_id=session_id,
+    ):
+      return
 
     is_duplicate = self._check_duplicate_last(
       payload=delta_config_stream,
@@ -65,7 +180,6 @@ class ConfigCommandHandlers:
       # return
     #endif
 
-    config_stream = self.dct_config_streams.get(stream_name, {})
     is_new = False
     if len(config_stream) > 0:
       msg = "Received {} command to update for existing pipeline '{}' ({}) from {}:{}".format(
@@ -117,6 +231,7 @@ class ConfigCommandHandlers:
       stream_name = config_stream[ct.CONFIG_STREAM.NAME]
       self._save_stream_config(config_stream)
       self.dct_config_streams[stream_name] = config_stream
+      self._clear_deeploy_lifecycle_tombstone(stream_name)
       
       str_new = "new" if is_new else "existing"
       msg = "Successfully updated {} configuration for pipeline '{}' initiated by '{}'".format(str_new, stream_name, initiator_id)
@@ -362,6 +477,18 @@ class ConfigCommandHandlers:
   
   
   def delete_config_stream(self, stream_name, initiator_id, session_id, verbose=1):
+    stream_name, delete_payload = self._normalize_delete_config_payload(stream_name)
+    if not isinstance(stream_name, str) or len(stream_name) == 0:
+      msg = "Attempt to delete a pipeline with no/wrong pipeline name/information: {}.".format(stream_name)
+      self.P(msg, color='r')
+      self._create_notification(
+        notif=ct.STATUS_TYPE.STATUS_ABNORMAL_FUNCTIONING,
+        msg=msg,
+        stream_name=stream_name,
+        displayed=True,
+      )
+      return
+
     if stream_name not in self.dct_config_streams:
       msg = "Attempted to delete pipeline '{}' that does not exist. Current pipelines: {}".format(
         stream_name, list(self.dct_config_streams.keys())
@@ -389,6 +516,21 @@ class ConfigCommandHandlers:
     if initiator_id is None:
       initiator_id = self.dct_config_streams[stream_name].get(ct.PAYLOAD_DATA.INITIATOR_ID)
 
+    current_config_stream = self.dct_config_streams[stream_name]
+    if self._should_skip_stale_deeploy_lifecycle_command(
+      command_name=ct.PAYLOAD_CT.COMMANDS.DELETE_CONFIG,
+      stream_name=stream_name,
+      incoming_payload=delete_payload,
+      current_payload=current_config_stream,
+      initiator_id=initiator_id,
+      session_id=session_id,
+    ):
+      return
+
+    self._remember_deeploy_lifecycle_tombstone(
+      stream_name=stream_name,
+      payload=delete_payload or current_config_stream,
+    )
     self._delete_stream_config(stream_name)
     self.dct_config_streams.pop(stream_name)
     


### PR DESCRIPTION
## Summary
- accept structured Deeploy `DELETE_CONFIG` payloads while preserving legacy string deletes
- compare Deeploy lifecycle markers on update/delete and skip stale commands
- add fixture-backed receiver tests for old delete after newer update and same-runtime tombstone behavior

## Why
Cap_34 showed an older Deeploy delete can arrive after a newer update and stop the refreshed app. This adds the receiver-side half of the ordering contract.

## Validation
- `/home/bleot/venvs/umbrella313/bin/python -m unittest naeural_core.business.test_framework.test_deeploy_lifecycle_ordering` -> 7 tests passed
- `/home/bleot/venvs/umbrella313/bin/python -m compileall naeural_core/config/config_manager_commands.py naeural_core/business/mixins_base/cmdapi.py naeural_core/business/test_framework/test_deeploy_lifecycle_ordering.py`
- `git diff --check`
- Two-node Deeploy Docker testbed run from the dependent `edge_node` branch with this local core mounted: create generation 1, update generation 2, stale delete ignored, current delete accepted, result `ok`

## Notes
- Required before the companion `edge_node` PR is deployed; the edge branch emits structured delete payloads.
- Legacy string `DELETE_CONFIG` remains unconditional.
- Durable tombstones across receiver restart are not included in this slice.